### PR TITLE
Fix Kodama finalizeSpawn using world random off-thread (C2ME / parallel worldgen)

### DIFF
--- a/common/src/main/java/dev/xylonity/bonsai/ghosts/common/entity/kodama/KodamaEntity.java
+++ b/common/src/main/java/dev/xylonity/bonsai/ghosts/common/entity/kodama/KodamaEntity.java
@@ -356,7 +356,10 @@ public class KodamaEntity extends PassiveEntity {
     @Override
     public SpawnGroupData finalizeSpawn(ServerLevelAccessor level, DifficultyInstance difficulty, MobSpawnType spawnType, @Nullable SpawnGroupData spawnGroupData) {
         if (getVariant() == 0) {
-            setVariant(level.getLevel().random.nextInt(4) + 1);
+            // Do not use the world's BitRandomSource here: finalizeSpawn can run on C2ME (or other)
+            // parallel worldgen worker threads, which is not thread-safe for server-level random.
+            long variantSeed = this.blockPosition().asLong() ^ level.getLevel().getSeed();
+            setVariant(RandomSource.create(variantSeed).nextInt(4) + 1);
         }
 
         return super.finalizeSpawn(level, difficulty, spawnType, spawnGroupData);


### PR DESCRIPTION
### Summary

`KodamaEntity.finalizeSpawn` was calling `level.getLevel().random` to pick the visual variant. That uses the world’s `BitRandomSource`, which is only safe on the owning server thread. Mob spawn finalization can run on parallel worldgen worker threads (e.g. with **Concurrent Chunk Management Engine / C2ME**), which triggers unsafe-world-random detection and can crash chunk generation.

This change derives the variant from a dedicated `RandomSource` seeded with `blockPosition().asLong() ^ level.getLevel().getSeed()`, so variant selection no longer touches the world random during `finalizeSpawn`.

### Linked issue

- Closes / relates to [#9 – Crash during worldgen when KodamaEntity spawns (ThreadLocalRandom accessed from different thread)](https://github.com/bonsaistudi0s/Ghosts/issues/9)

### Testing

- [ ] Load a world with C2ME (or similar parallel worldgen) and explore new chunks in overworld night conditions where Kodama can spawn; confirm no `CheckedThreadLocalRandom` / chunk-gen crash.
- [ ] Spawn Kodama (natural or egg) and confirm variant still varies as expected across positions.

### Notes

- Target base branch **`v1.21.1`** for the 1.21.1 NeoForge